### PR TITLE
Fix word display row wrap

### DIFF
--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -323,7 +323,7 @@ export default function Component() {
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="text-center">
-                <div className="text-3xl font-mono font-bold tracking-wider mb-4 p-4 bg-gray-100 rounded-lg">
+                <div className="text-3xl font-mono font-bold tracking-wider mb-4 p-4 bg-gray-100 rounded-lg overflow-x-auto whitespace-nowrap">
                   {displayWord}
                 </div>
                 <p className="text-sm text-gray-600">Brain Region ({currentWord.length} letters)</p>


### PR DESCRIPTION
## Summary
- keep the displayed word on a single row so the underscores don't wrap

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882bee28834832cbe79cb15596f0a95