### PR TITLE
Add dark mode feature

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { ThemeProvider } from "@/components/theme-provider"
+import { Toaster } from '@/components/ui/toaster'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -17,6 +18,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
         </ThemeProvider>
+        <Toaster />
       </body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { ThemeProvider } from "@/components/theme-provider"
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -9,12 +10,14 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Button } from "@/components/ui/button"
+import { Sun, Moon } from "lucide-react"
+
+export function ModeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark")
+  }
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -268,15 +268,15 @@ export default function Component() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 p-4">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 dark:from-gray-900 dark:to-gray-800 p-4">
       <div className="max-w-4xl mx-auto">
         <div className="flex justify-end mb-4">
           <ModeToggle />
         </div>
         <Card className="mb-6">
           <CardHeader className="text-center">
-            <CardTitle className="text-4xl font-bold text-purple-700">🧠 HangBrain</CardTitle>
-            <p className="text-gray-600">Guess the brain region before all areas are colored!</p>
+            <CardTitle className="text-4xl font-bold text-purple-700 dark:text-purple-300">🧠 HangBrain</CardTitle>
+            <p className="text-gray-600 dark:text-gray-300">Guess the brain region before all areas are colored!</p>
           </CardHeader>
         </Card>
 
@@ -327,10 +327,10 @@ export default function Component() {
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="text-center">
-                <div className="text-3xl font-mono font-bold tracking-wider mb-4 p-4 bg-gray-100 rounded-lg overflow-x-auto whitespace-nowrap">
+                <div className="text-3xl font-mono font-bold tracking-wider mb-4 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg overflow-x-auto whitespace-nowrap">
                   {displayWord}
                 </div>
-                <p className="text-sm text-gray-600">Brain Region ({currentWord.length} letters)</p>
+                <p className="text-sm text-gray-600 dark:text-gray-300">Brain Region ({currentWord.length} letters)</p>
               </div>
 
               {gameStatus === "playing" && (
@@ -366,7 +366,7 @@ export default function Component() {
 
               {gameStatus === "won" && (
                 <div className="text-center space-y-4">
-                  <div className="text-2xl font-bold text-green-600">🎉 Congratulations!</div>
+                  <div className="text-2xl font-bold text-green-600 dark:text-green-400">🎉 Congratulations!</div>
                   <p>
                     You correctly guessed: <strong>{currentWord}</strong>
                   </p>
@@ -378,7 +378,7 @@ export default function Component() {
 
               {gameStatus === "lost" && (
                 <div className="text-center space-y-4">
-                  <div className="text-2xl font-bold text-red-600">💀 Game Over!</div>
+                  <div className="text-2xl font-bold text-red-600 dark:text-red-400">💀 Game Over!</div>
                   <p>
                     The brain region was: <strong>{currentWord}</strong>
                   </p>
@@ -394,7 +394,7 @@ export default function Component() {
         <Card className="mt-6">
           <CardContent className="pt-6">
             <h3 className="font-bold mb-2">How to Play:</h3>
-            <ul className="text-sm text-gray-600 space-y-1">
+            <ul className="text-sm text-gray-600 dark:text-gray-300 space-y-1">
               <li>• Guess letters to reveal the hidden brain region</li>
               <li>• Each wrong guess colors a different brain region</li>
               <li>• Win by guessing the word before all regions are colored</li>

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -8,6 +8,8 @@ import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ModeToggle } from "@/components/mode-toggle"
+import { toast } from "@/hooks/use-toast"
+import { cn } from "@/lib/utils"
 
 const BRAIN_REGIONS = [
   // Cerebral cortex regions
@@ -170,6 +172,7 @@ export default function Component() {
   const [wrongGuesses, setWrongGuesses] = useState(0)
   const [gameStatus, setGameStatus] = useState<"playing" | "won" | "lost">("playing")
   const [guess, setGuess] = useState("")
+  const alphabet = Array.from({ length: 26 }, (_, i) => String.fromCharCode(97 + i))
 
   const initializeGame = () => {
     const randomWord = BRAIN_REGIONS[Math.floor(Math.random() * BRAIN_REGIONS.length)]
@@ -185,7 +188,12 @@ export default function Component() {
   }, [])
 
   const handleGuess = () => {
-    if (!guess || guess.length !== 1 || guessedLetters.includes(guess.toLowerCase())) {
+    if (!guess || guess.length !== 1) {
+      return
+    }
+
+    if (guessedLetters.includes(guess.toLowerCase())) {
+      toast({ title: "You already tried that letter" })
       return
     }
 
@@ -209,9 +217,12 @@ export default function Component() {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.slice(0, 1).toLowerCase()
     // Don't allow already guessed letters
-    if (!guessedLetters.includes(value)) {
-      setGuess(value)
+    if (guessedLetters.includes(value)) {
+      toast({ title: "You already tried that letter" })
+      return
     }
+
+    setGuess(value)
   }
 
   useEffect(() => {
@@ -352,13 +363,26 @@ export default function Component() {
                   </div>
 
                   <div>
-                    <p className="text-sm font-medium mb-2">Guessed letters:</p>
+                    <p className="text-sm font-medium mb-2">Letters:</p>
                     <div className="flex flex-wrap gap-1">
-                      {guessedLetters.map((letter: string) => (
-                        <Badge key={letter} variant={currentWord.includes(letter) ? "default" : "destructive"}>
-                          {letter.toUpperCase()}
-                        </Badge>
-                      ))}
+                      {alphabet.map((letter) => {
+                        const guessed = guessedLetters.includes(letter)
+                        const correct = guessed && currentWord.includes(letter)
+                        return (
+                          <Badge
+                            key={letter}
+                            className={cn(
+                              guessed
+                                ? correct
+                                  ? "bg-green-500 text-white"
+                                  : "bg-red-500 text-white"
+                                : "bg-gray-200 text-gray-700"
+                            )}
+                          >
+                            {letter.toUpperCase()}
+                          </Badge>
+                        )
+                      })}
                     </div>
                   </div>
                 </div>

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { ModeToggle } from "@/components/mode-toggle"
 
 const BRAIN_REGIONS = [
   // Cerebral cortex regions
@@ -269,6 +270,9 @@ export default function Component() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 p-4">
       <div className="max-w-4xl mx-auto">
+        <div className="flex justify-end mb-4">
+          <ModeToggle />
+        </div>
         <Card className="mb-6">
           <CardHeader className="text-center">
             <CardTitle className="text-4xl font-bold text-purple-700">🧠 HangBrain</CardTitle>


### PR DESCRIPTION
## Summary
- integrate `ThemeProvider` in layout
- add `ModeToggle` component for switching themes
- place toggle in the HangBrain page

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6882c10b6804832cbd33a09a2c00a86c