### PR TITLE
Add alphabet display and repeated guess toast

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { Toaster } from '@/components/ui/toaster'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +15,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Toaster />
+      </body>
     </html>
   )
 }

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { toast } from "@/hooks/use-toast"
+import { cn } from "@/lib/utils"
 
 const BRAIN_REGIONS = [
   // Cerebral cortex regions
@@ -169,6 +171,7 @@ export default function Component() {
   const [wrongGuesses, setWrongGuesses] = useState(0)
   const [gameStatus, setGameStatus] = useState<"playing" | "won" | "lost">("playing")
   const [guess, setGuess] = useState("")
+  const alphabet = Array.from({ length: 26 }, (_, i) => String.fromCharCode(97 + i))
 
   const initializeGame = () => {
     const randomWord = BRAIN_REGIONS[Math.floor(Math.random() * BRAIN_REGIONS.length)]
@@ -184,7 +187,12 @@ export default function Component() {
   }, [])
 
   const handleGuess = () => {
-    if (!guess || guess.length !== 1 || guessedLetters.includes(guess.toLowerCase())) {
+    if (!guess || guess.length !== 1) {
+      return
+    }
+
+    if (guessedLetters.includes(guess.toLowerCase())) {
+      toast({ title: "You already tried that letter" })
       return
     }
 
@@ -208,9 +216,12 @@ export default function Component() {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.slice(0, 1).toLowerCase()
     // Don't allow already guessed letters
-    if (!guessedLetters.includes(value)) {
-      setGuess(value)
+    if (guessedLetters.includes(value)) {
+      toast({ title: "You already tried that letter" })
+      return
     }
+
+    setGuess(value)
   }
 
   useEffect(() => {
@@ -348,13 +359,26 @@ export default function Component() {
                   </div>
 
                   <div>
-                    <p className="text-sm font-medium mb-2">Guessed letters:</p>
+                    <p className="text-sm font-medium mb-2">Letters:</p>
                     <div className="flex flex-wrap gap-1">
-                      {guessedLetters.map((letter: string) => (
-                        <Badge key={letter} variant={currentWord.includes(letter) ? "default" : "destructive"}>
-                          {letter.toUpperCase()}
-                        </Badge>
-                      ))}
+                      {alphabet.map((letter) => {
+                        const guessed = guessedLetters.includes(letter)
+                        const correct = guessed && currentWord.includes(letter)
+                        return (
+                          <Badge
+                            key={letter}
+                            className={cn(
+                              guessed
+                                ? correct
+                                  ? "bg-green-500 text-white"
+                                  : "bg-red-500 text-white"
+                                : "bg-gray-200 text-gray-700"
+                            )}
+                          >
+                            {letter.toUpperCase()}
+                          </Badge>
+                        )
+                      })}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- display a toast notification when a letter was already tried
- show entire alphabet with guessed letters highlighted
- mount the toast provider

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882c0d7b4f8832c9d89d79de8f9ebb7