### PR TITLE
feat: show brain region info after round

### DIFF
--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -504,19 +504,19 @@ export default function Component() {
                       )}
                     </div>
                   )}
+                  <Button onClick={initializeGame} className="w-full">
+                    Play Again
+                  </Button>
                   <a
                     href={`https://en.wikipedia.org/w/index.php?search=${encodeURIComponent(
                       currentWord + " brain",
                     )}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline text-blue-600 block"
+                    className="underline text-blue-600 block mt-2"
                   >
                     Not the correct page about the brain region? Click here to find the correct description
                   </a>
-                  <Button onClick={initializeGame} className="w-full">
-                    Play Again
-                  </Button>
                 </div>
               )}
 
@@ -543,19 +543,19 @@ export default function Component() {
                       )}
                     </div>
                   )}
+                  <Button onClick={initializeGame} className="w-full">
+                    Try Again
+                  </Button>
                   <a
                     href={`https://en.wikipedia.org/w/index.php?search=${encodeURIComponent(
                       currentWord + " brain",
                     )}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline text-blue-600 block"
+                    className="underline text-blue-600 block mt-2"
                   >
                     Not the correct page about the brain region? Click here to find the correct description
                   </a>
-                  <Button onClick={initializeGame} className="w-full">
-                    Try Again
-                  </Button>
                 </div>
               )}
             </CardContent>

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -427,7 +427,9 @@ export default function Component() {
                   </p>
                   {regionInfo && (
                     <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2">
-                      <p>{regionInfo.description}</p>
+                      <p>
+                        <strong>About {regionInfo.title}:</strong> {regionInfo.description}
+                      </p>
                       {regionInfo.url && (
                         <a
                           href={regionInfo.url}
@@ -454,7 +456,9 @@ export default function Component() {
                   </p>
                   {regionInfo && (
                     <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2">
-                      <p>{regionInfo.description}</p>
+                      <p>
+                        <strong>About {regionInfo.title}:</strong> {regionInfo.description}
+                      </p>
                       {regionInfo.url && (
                         <a
                           href={regionInfo.url}

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -159,6 +159,10 @@ export default function Component() {
   const [gameStatus, setGameStatus] = useState<"playing" | "won" | "lost">("playing")
   const [wins, setWins] = useState(0)
   const [losses, setLosses] = useState(0)
+  const [regionInfo, setRegionInfo] = useState<
+    | { title: string; description: string; url: string }
+    | null
+  >(null)
   const alphabet = Array.from({ length: 26 }, (_, i) => String.fromCharCode(97 + i))
 
   const initializeGame = () => {
@@ -238,6 +242,36 @@ export default function Component() {
       })
     }
   }, [gameStatus])
+
+  useEffect(() => {
+    const fetchRegionInfo = async () => {
+      if (gameStatus === "won" || gameStatus === "lost") {
+        try {
+          const response = await fetch(
+            `https://en.wikipedia.org/w/api.php?action=opensearch&search=${encodeURIComponent(
+              currentWord,
+            )}&limit=1&namespace=0&format=json&origin=*`,
+          )
+          const data = await response.json()
+          if (data && data[1] && data[1].length > 0) {
+            setRegionInfo({
+              title: data[1][0],
+              description: data[2][0] || "",
+              url: data[3][0] || "",
+            })
+          } else {
+            setRegionInfo(null)
+          }
+        } catch (error) {
+          setRegionInfo(null)
+        }
+      } else {
+        setRegionInfo(null)
+      }
+    }
+
+    fetchRegionInfo()
+  }, [gameStatus, currentWord])
 
   const displayWord = currentWord
     .split("")
@@ -391,6 +425,21 @@ export default function Component() {
                   <p>
                     You correctly guessed: <strong>{currentWord}</strong>
                   </p>
+                  {regionInfo && (
+                    <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2">
+                      <p>{regionInfo.description}</p>
+                      {regionInfo.url && (
+                        <a
+                          href={regionInfo.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline text-blue-600"
+                        >
+                          Learn more on Wikipedia
+                        </a>
+                      )}
+                    </div>
+                  )}
                   <Button onClick={initializeGame} className="w-full">
                     Play Again
                   </Button>
@@ -403,6 +452,21 @@ export default function Component() {
                   <p>
                     The brain region was: <strong>{currentWord}</strong>
                   </p>
+                  {regionInfo && (
+                    <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2">
+                      <p>{regionInfo.description}</p>
+                      {regionInfo.url && (
+                        <a
+                          href={regionInfo.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline text-blue-600"
+                        >
+                          Learn more on Wikipedia
+                        </a>
+                      )}
+                    </div>
+                  )}
                   <Button onClick={initializeGame} className="w-full">
                     Try Again
                   </Button>

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -254,7 +254,7 @@ export default function Component() {
         const searchResponse = await fetch(
           `https://en.wikipedia.org/w/api.php?action=opensearch&search=${encodeURIComponent(
             currentWord,
-          )}&limit=1&namespace=0&format=json&origin=*`,
+          )}&limit=5&namespace=0&format=json&origin=*`,
         )
         const searchData = await searchResponse.json()
         if (!searchData || !searchData[1] || searchData[1].length === 0) {
@@ -262,7 +262,30 @@ export default function Component() {
           return
         }
 
-        const title = searchData[1][0]
+        const titles: string[] = searchData[1]
+        const descriptions: string[] = searchData[2]
+        const urls: string[] = searchData[3]
+        const keywords = [
+          "brain",
+          "neuro",
+          "cortex",
+          "lobe",
+          "nucleus",
+          "gyrus",
+          "nerve",
+          "cerebellum",
+          "thalamus",
+          "midbrain",
+          "hypothalamus",
+          "cerebral",
+          "spinal",
+        ]
+        let index = titles.findIndex((_, i) => {
+          const text = `${titles[i]} ${descriptions[i]}`.toLowerCase()
+          return keywords.some((kw) => text.includes(kw))
+        })
+        if (index === -1) index = 0
+        const title = titles[index]
         try {
           const summaryResponse = await fetch(
             `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`,
@@ -271,15 +294,14 @@ export default function Component() {
           const summaryData = await summaryResponse.json()
           setRegionInfo({
             title: summaryData.title || title,
-            description: summaryData.extract || searchData[2][0] || "",
-            url:
-              summaryData.content_urls?.desktop?.page || searchData[3][0] || "",
+            description: summaryData.extract || descriptions[index] || "",
+            url: summaryData.content_urls?.desktop?.page || urls[index] || "",
           })
         } catch {
           setRegionInfo({
             title,
-            description: searchData[2][0] || "",
-            url: searchData[3][0] || "",
+            description: descriptions[index] || "",
+            url: urls[index] || "",
           })
         }
       } catch {

--- a/hangbrain.tsx
+++ b/hangbrain.tsx
@@ -507,16 +507,6 @@ export default function Component() {
                   <Button onClick={initializeGame} className="w-full">
                     Play Again
                   </Button>
-                  <a
-                    href={`https://en.wikipedia.org/w/index.php?search=${encodeURIComponent(
-                      currentWord + " brain",
-                    )}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline text-blue-600 block mt-2"
-                  >
-                    Not the correct page about the brain region? Click here to find the correct description
-                  </a>
                 </div>
               )}
 
@@ -546,16 +536,6 @@ export default function Component() {
                   <Button onClick={initializeGame} className="w-full">
                     Try Again
                   </Button>
-                  <a
-                    href={`https://en.wikipedia.org/w/index.php?search=${encodeURIComponent(
-                      currentWord + " brain",
-                    )}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline text-blue-600 block mt-2"
-                  >
-                    Not the correct page about the brain region? Click here to find the correct description
-                  </a>
                 </div>
               )}
             </CardContent>
@@ -573,6 +553,20 @@ export default function Component() {
             </ul>
           </CardContent>
         </Card>
+        {(gameStatus === "won" || gameStatus === "lost") && (
+          <div className="text-center mt-4">
+            <a
+              href={`https://en.wikipedia.org/w/index.php?search=${encodeURIComponent(
+                currentWord + " brain",
+              )}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-blue-600"
+            >
+              Not the correct page about the brain region? Click here to find the correct description
+            </a>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- fetch brain region info from Wikipedia's open search after a game ends
- display region description and link in both win and loss screens

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a108cb528832ca0c08de151cc195c